### PR TITLE
bumpversion: remove setup.py file from bumpersion config

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,8 +3,6 @@ current_version = 0.1.0
 commit = True
 tag = True
 
-[bumpversion:file:setup.py]
-
 [bumpversion:file:djangomailup/__init__.py]
 
 [wheel]


### PR DESCRIPTION
setup.py get the version from __init__.py and don't have harcoded vesion in it.