### PR TITLE
endpoint: update lists url

### DIFF
--- a/djangomailup/conf.py
+++ b/djangomailup/conf.py
@@ -13,5 +13,5 @@ ENDPOINT = {
     "authorize": "{}LogOn".format(AUTHORIZE),
     "token": "{}Token".format(AUTHORIZE),
     "info": "{}Authentication/Info".format(CONSOLE),
-    "lists": "{}User/Lists".format(CONSOLE),
+    "lists": "{}Lists".format(CONSOLE),
 }

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -101,7 +101,7 @@ class TestDjangoMailupApi(TestCase):
         url = (
             "https://services.mailup.com/API/v1.1/Rest/"
             "ConsoleService.svc/Console/"
-            "User/Lists"
+            "Lists"
         )
         with requests_mock.mock() as m:
             m.get(url, json={
@@ -131,7 +131,7 @@ class TestDjangoMailupApi(TestCase):
         url = (
             "https://services.mailup.com/API/v1.1/Rest/"
             "ConsoleService.svc/Console/"
-            "User/Lists"
+            "Lists"
         )
         with requests_mock.mock() as m:
             m.post(url, json={
@@ -153,7 +153,7 @@ class TestDjangoMailupApi(TestCase):
         url = (
             "https://services.mailup.com/API/v1.1/Rest/"
             "ConsoleService.svc/Console/"
-            "User/Lists/2"
+            "Lists/2"
         )
         with requests_mock.mock() as m:
             m.post(url, json={
@@ -194,7 +194,7 @@ class TestDjangoMailupApi(TestCase):
         url = (
             "https://services.mailup.com/API/v1.1/Rest/"
             "ConsoleService.svc/Console/"
-            "User/Lists/3"
+            "Lists/3"
         )
         with requests_mock.mock() as m:
             m.post(url, json={


### PR DESCRIPTION
fix deprecation

ref http://help.mailup.com/display/mailupapi/Manage+Lists+and+Groups#ManageListsandGroups-Oldreadlistsmethod